### PR TITLE
added 5 seconds delay before calling media_play

### DIFF
--- a/jukebox-card.js
+++ b/jukebox-card.js
@@ -185,6 +185,10 @@ class JukeboxCard extends HTMLElement {
             media_content_id: e.currentTarget.stationUrl,
             media_content_type: 'audio/mp4'
         });
+        setTimeout(function() {
+            this.hass.callService('media_player', 'media_play', {
+                entity_id: this._selectedSpeaker});
+        }, 5000);
     }
 
     setVolume(value) {


### PR DESCRIPTION
A potential workaround described here https://github.com/home-assistant/core/issues/16319#issuecomment-476351385 for the 40+ seconds delay after pressing Play button for local Icecast relay of an Internet radion stream